### PR TITLE
Escape angle brackets in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 * Must have 99.99% cache hit rate
 * Cache miss - render time must be under 5ms
 * Main document must fit to one jumbo frame (Transit layer could be IPv4 or IPv6)
-* Five Star Hot swap deployment technology<TM> must be used and the target is 1440 deployments per day.
+* Five Star Hot swap deployment technology\<TM\> must be used and the target is 1440 deployments per day.
 
 # Future plans
 * High Availability - Introduce espoo Datacenter


### PR DESCRIPTION
Otherwise, the text in angle brackets is interpreted as a HTML tag when contents are rendered.