### PR TITLE
Implement a service worker to cache static content

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,3 @@
 
 # Future plans
 * High Availability - Introduce espoo Datacenter
-* Offline experience with service worker
-

--- a/index.html
+++ b/index.html
@@ -23,5 +23,6 @@
       name="next-player-01"
       src="https://video.nest.com/embedded/live/Gmt1BYseCd?autoplay=1"
     ></iframe>
+    <script src="index.js"></script>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+async function registerServiceWorker() {
+  if ("serviceWorker" in navigator) {
+    await navigator.serviceWorker.register("sw.js");
+  }
+}
+
+registerServiceWorker();

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,39 @@
+const pathPrefix = location.pathname.replace(/\/sw\.js$/, "");
+const staticResources = [
+  `${pathPrefix}`,
+  `${pathPrefix}/`,
+  `${pathPrefix}/index.html`,
+  `${pathPrefix}/index.js`,
+  `${pathPrefix}/style.css`,
+];
+
+async function cacheResources(resources) {
+  const cache = await caches.open("v1");
+  await cache.addAll(resources);
+}
+
+async function getCachedAndRefresh(request) {
+  const cacheMatch = await caches.match(request);
+  const response = fetch(request).then(async (response) => {
+    if (response.ok) {
+      const cache = await caches.open("v1");
+      cache.put(request, response.clone());
+    }
+
+    return response;
+  });
+
+  return cacheMatch || (await response);
+}
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+
+  if (staticResources.includes(url.pathname)) {
+    event.respondWith(getCachedAndRefresh(event.request));
+  }
+});
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(cacheResources(staticResources));
+});


### PR DESCRIPTION
The service worker will return cached contents always, but it will refresh cache if the server is reachable. To refresh cached static contents in the browser, two reloads are required.